### PR TITLE
readme: use correct branch in links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Specifying an R environment with a runtime.txt file
 
-Jupyter+R: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/binder-examples/r/master?filepath=index.ipynb)
+Jupyter+R: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/binder-examples/r/main?filepath=index.ipynb)
 
-RStudio: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=rstudio)
+RStudio: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/binder-examples/r/main?urlpath=rstudio)
 
-RShiny: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=shiny/bus-dashboard/)
+RShiny: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/binder-examples/r/main?urlpath=shiny/bus-dashboard/)
 
 Binder supports using R and RStudio, with libraries pinned to a specific
 snapshot on [packagemanager.rstudio.com](https://packagemanager.rstudio.com/client/#/).
@@ -40,7 +40,7 @@ Both [RStudio](https://www.rstudio.com/) and [IRKernel](https://irkernel.github.
 are installed by default, so you can use either the Jupyter notebook interface or
 the RStudio interface.
 
-This repository also contains an example of a [Shiny app](https://github.com/binder-examples/r/tree/master/bus-dashboard).
+This repository also contains an example of a [Shiny app](https://github.com/binder-examples/r/tree/main/bus-dashboard).
 
 ## Alternatives
 
@@ -66,11 +66,11 @@ the URL of our original repository from GitHub or Figshare, etc.
 
 - For the RStudio environment, we must add the following at the end of the URL: `?urlpath=rstudio`
 
-  - Example: http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=rstudio
+  - Example: http://mybinder.org/v2/gh/binder-examples/r/main?urlpath=rstudio
 
 - For the Shiny app environment, we must add the following at the end of the URL: `?urlpath=shiny`. In this case, we
 also have to note that if the Shiny app files are located in a folder, this folder should be specified in the URL,
 after a slash. We would then also have to put in a trailing slash at the end of the URL, and to avoid spaces in the
 name of the repository, placing instead a hyphen (the reason is that spaces are converted to `%20`).
 
-  - Example: http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=shiny/bus-dashboard/
+  - Example: http://mybinder.org/v2/gh/binder-examples/r/main?urlpath=shiny/bus-dashboard/


### PR DESCRIPTION
I was wondering why none of the links were working, seems somebody changed the default branch name but did not update the readme.